### PR TITLE
Remove reference to undeclared function to fix fatal on theme change

### DIFF
--- a/inc/class-network-plugin-auditor.php
+++ b/inc/class-network-plugin-auditor.php
@@ -50,7 +50,6 @@ class NetworkPluginAuditor {
 		// Clear the transients when plugin or themes change.
 		add_action( 'activated_plugin', array( $this, 'clear_plugin_transient' ), 10, 2 );
 		add_action( 'deactivated_plugin', array( $this, 'clear_plugin_transient' ), 10, 2 );
-		add_action( 'switch_theme', array( $this, 'clear_theme_transient' ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
`clear_theme_transient` is no longer defined on this class, so attempting to switch themes with this plugin active causes a fatal error. There may be an alternative fix available upstream, I have not checked.