### PR TITLE
WP CLI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # ignore the entire SVN repo folder
 svnrepo
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,5 @@
 			"name": "Katherine Semel",
 			"email": "ksemel@gmail.com"
 		}
-	],
-	"autoload": {
-		"files": [
-			"network-plugin-auditor.php"
-		]
-	}
+	]
 }

--- a/inc/class-base-command.php
+++ b/inc/class-base-command.php
@@ -14,140 +14,138 @@ namespace NetworkPluginAuditor\WPCLI;
 use WP_CLI;
 use WP_Site;
 
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
+/**
+ * A base command for WP-CLI.
+ */
+abstract class Base_Command {
+	protected array $sites;
+
 	/**
-	 * A base command for WP-CLI.
+	 * Executes the command to retrieve and store all sites in a multisite installation.
+	 *
+	 * @param array $args Positional arguments passed to the command.
+	 * @param array $assoc_args Associative arguments passed to the command.
+	 *
+	 * @return void
 	 */
-	abstract class Base_Command {
-		protected array $sites;
+	public function run( array $args, array $assoc_args ) : void {
+		if ( ! is_multisite() ) {
+			WP_CLI::error( 'This command can only be run on a multisite installation.' );
 
-		/**
-		 * Executes the command to retrieve and store all sites in a multisite installation.
-		 *
-		 * @param array $args Positional arguments passed to the command.
-		 * @param array $assoc_args Associative arguments passed to the command.
-		 *
-		 * @return void
-		 */
-		public function run( array $args, array $assoc_args ) : void {
-			if ( ! is_multisite() ) {
-				WP_CLI::error( 'This command can only be run on a multisite installation.' );
-
-				return;
-			}
-
-			$sites = get_sites( [ 'number' => 0 ] ); // Get all sites
-			if ( empty( $sites ) ) {
-				WP_CLI::error( 'No sites found in the network.' );
-
-				return;
-			}
-
-			$this->sites = $sites;
+			return;
 		}
 
-		/**
-		 * Generates a filtered and sorted table based on active plugins or themes across a multisite installation.
-		 *
-		 * @param array  $list A list of plugins or themes to evaluate for active status.
-		 * @param array  $assoc_args An associative array of filters and sorting criteria, including:
-		 *                          - 'order-by': Sort the table by 'name' or 'active-sites'.
-		 *                          - 'min-active-sites': Minimum number of active sites required for inclusion.
-		 *                          - 'max-active-sites': Maximum number of active sites allowed for inclusion.
-		 *                          - 'site-id': Filter by a specific site ID.
-		 * @param string $column_name The name of the primary column to display in the table.
-		 *
-		 * @return array A filtered and sorted array of data, where each entry contains:
-		 *               - The primary column key with the plugin/theme name.
-		 *               - 'Active Sites': The count of sites where the plugin/theme is active.
-		 *               - 'Site IDs': A comma-separated list of site IDs where the plugin/theme is active.
-		 */
-		public function get_table( array $list, array $assoc_args, string $column_name ) : array {
-			$active_counts = array_fill_keys( $list, 0 );
-			$active_sites = array_fill_keys( $list, [] );
+		$sites = get_sites( [ 'number' => 0 ] ); // Get all sites
+		if ( empty( $sites ) ) {
+			WP_CLI::error( 'No sites found in the network.' );
 
-			// Count active themes per site and store site IDs
-			foreach ( $this->sites as $site ) {
-				$plugins_or_themes = $this->before_count( $site );
-
-				foreach ( $plugins_or_themes as $plugin_or_theme ) {
-					if ( isset( $active_counts[ $plugin_or_theme ] ) ) {
-						$active_counts[ $plugin_or_theme ] ++;
-					} else {
-						$active_counts[ $plugin_or_theme ] = 1;
-					}
-
-					if ( isset( $active_sites[ $plugin_or_theme ] ) ) {
-						$active_sites[ $plugin_or_theme ][] = $site->blog_id;
-					} else {
-						$active_sites[ $plugin_or_theme ] = [ $site->blog_id ];
-					}
-				}
-
-				$this->after_count();
-			}
-
-			// Apply filters
-			$order_by = $assoc_args['order-by'] ?? 'name';
-			$min_sites_active = isset( $assoc_args['min-active-sites'] ) ? (int) $assoc_args['min-active-sites'] : null;
-			$max_sites_active = isset( $assoc_args['max-active-sites'] ) ? (int) $assoc_args['max-active-sites'] : null;
-			$filter_site_id = isset( $assoc_args['site-id'] ) ? (int) $assoc_args['site-id'] : null;
-
-			$table = [];
-			foreach ( $active_counts as $plugin_or_theme => $count ) {
-				// Apply min/max filters
-				if (
-					( $min_sites_active !== null && $count < $min_sites_active ) ||
-					( $max_sites_active !== null && $count > $max_sites_active )
-				) {
-					continue;
-				}
-
-				// Apply site ID filter, if provided
-				if (
-					$filter_site_id !== null &&
-					( empty( $active_sites[ $plugin_or_theme ] ) || ! in_array( $filter_site_id, $active_sites[ $plugin_or_theme ], false ) )
-				) {
-					continue;
-				}
-
-				$table[] = [
-					$column_name => $plugin_or_theme,
-					'Active Sites' => $count,
-					'Site IDs' => empty( $active_sites[ $plugin_or_theme ] ) ? 'None' : implode( ', ', $active_sites[ $plugin_or_theme ] ),
-				];
-			}
-
-			// Sort the table
-			if ( $order_by === 'active-sites' ) {
-				usort( $table, static function ( $a, $b ) {
-					return $b['Active Sites'] <=> $a['Active Sites'];
-				} );
-			} else {
-				usort( $table, static function ( $a, $b ) use ( $column_name ) {
-					return strcasecmp( $a[ $column_name ], $b[ $column_name ] );
-				} );
-			}
-
-			return $table;
+			return;
 		}
 
-		/**
-		 * Executes operations to be performed before a count is initiated.
-		 *
-		 * @param WP_Site $site The site object for which the count will be prepared.
-		 *
-		 * @return array An array of data to support the count operation.
-		 */
-		abstract protected function before_count( WP_Site $site ) : array;
+		$this->sites = $sites;
+	}
 
-		/**
-		 * Executes optional operations to be performed after a count is completed.
-		 *
-		 * @return void
-		 */
-		protected function after_count() : void {
-			// Optional
+	/**
+	 * Generates a filtered and sorted table based on active plugins or themes across a multisite installation.
+	 *
+	 * @param array  $list A list of plugins or themes to evaluate for active status.
+	 * @param array  $assoc_args An associative array of filters and sorting criteria, including:
+	 *                          - 'order-by': Sort the table by 'name' or 'active-sites'.
+	 *                          - 'min-active-sites': Minimum number of active sites required for inclusion.
+	 *                          - 'max-active-sites': Maximum number of active sites allowed for inclusion.
+	 *                          - 'site-id': Filter by a specific site ID.
+	 * @param string $column_name The name of the primary column to display in the table.
+	 *
+	 * @return array A filtered and sorted array of data, where each entry contains:
+	 *               - The primary column key with the plugin/theme name.
+	 *               - 'Active Sites': The count of sites where the plugin/theme is active.
+	 *               - 'Site IDs': A comma-separated list of site IDs where the plugin/theme is active.
+	 */
+	public function get_table( array $list, array $assoc_args, string $column_name ) : array {
+		$active_counts = array_fill_keys( $list, 0 );
+		$active_sites = array_fill_keys( $list, [] );
+
+		// Count active themes per site and store site IDs
+		foreach ( $this->sites as $site ) {
+			$plugins_or_themes = $this->before_count( $site );
+
+			foreach ( $plugins_or_themes as $plugin_or_theme ) {
+				if ( isset( $active_counts[ $plugin_or_theme ] ) ) {
+					$active_counts[ $plugin_or_theme ] ++;
+				} else {
+					$active_counts[ $plugin_or_theme ] = 1;
+				}
+
+				if ( isset( $active_sites[ $plugin_or_theme ] ) ) {
+					$active_sites[ $plugin_or_theme ][] = $site->blog_id;
+				} else {
+					$active_sites[ $plugin_or_theme ] = [ $site->blog_id ];
+				}
+			}
+
+			$this->after_count();
 		}
+
+		// Apply filters
+		$order_by = $assoc_args['order-by'] ?? 'name';
+		$min_sites_active = isset( $assoc_args['min-active-sites'] ) ? (int) $assoc_args['min-active-sites'] : null;
+		$max_sites_active = isset( $assoc_args['max-active-sites'] ) ? (int) $assoc_args['max-active-sites'] : null;
+		$filter_site_id = isset( $assoc_args['site-id'] ) ? (int) $assoc_args['site-id'] : null;
+
+		$table = [];
+		foreach ( $active_counts as $plugin_or_theme => $count ) {
+			// Apply min/max filters
+			if (
+				( $min_sites_active !== null && $count < $min_sites_active ) ||
+				( $max_sites_active !== null && $count > $max_sites_active )
+			) {
+				continue;
+			}
+
+			// Apply site ID filter, if provided
+			if (
+				$filter_site_id !== null &&
+				( empty( $active_sites[ $plugin_or_theme ] ) || ! in_array( $filter_site_id, $active_sites[ $plugin_or_theme ], false ) )
+			) {
+				continue;
+			}
+
+			$table[] = [
+				$column_name => $plugin_or_theme,
+				'Active Sites' => $count,
+				'Site IDs' => empty( $active_sites[ $plugin_or_theme ] ) ? 'None' : implode( ', ', $active_sites[ $plugin_or_theme ] ),
+			];
+		}
+
+		// Sort the table
+		if ( $order_by === 'active-sites' ) {
+			usort( $table, static function ( $a, $b ) {
+				return $b['Active Sites'] <=> $a['Active Sites'];
+			} );
+		} else {
+			usort( $table, static function ( $a, $b ) use ( $column_name ) {
+				return strcasecmp( $a[ $column_name ], $b[ $column_name ] );
+			} );
+		}
+
+		return $table;
+	}
+
+	/**
+	 * Executes operations to be performed before a count is initiated.
+	 *
+	 * @param WP_Site $site The site object for which the count will be prepared.
+	 *
+	 * @return array An array of data to support the count operation.
+	 */
+	abstract protected function before_count( WP_Site $site ) : array;
+
+	/**
+	 * Executes optional operations to be performed after a count is completed.
+	 *
+	 * @return void
+	 */
+	protected function after_count() : void {
+		// Optional
 	}
 }

--- a/inc/class-base-command.php
+++ b/inc/class-base-command.php
@@ -6,10 +6,10 @@
  * that operate on multisite installations. It includes methods to fetch site data,
  * process plugins or themes, and generate tabular output with various filters.
  *
- * @package NetworkPluginAuditor\WPCLI
+ * @package NetworkPluginAuditor\Commands
  */
 
-namespace NetworkPluginAuditor\WPCLI;
+namespace NetworkPluginAuditor\Commands;
 
 use WP_CLI;
 use WP_Site;

--- a/inc/class-base-command.php
+++ b/inc/class-base-command.php
@@ -72,17 +72,8 @@ abstract class Base_Command {
 			$plugins_or_themes = $this->before_count( $site );
 
 			foreach ( $plugins_or_themes as $plugin_or_theme ) {
-				if ( isset( $active_counts[ $plugin_or_theme ] ) ) {
-					$active_counts[ $plugin_or_theme ] ++;
-				} else {
-					$active_counts[ $plugin_or_theme ] = 1;
-				}
-
-				if ( isset( $active_sites[ $plugin_or_theme ] ) ) {
-					$active_sites[ $plugin_or_theme ][] = $site->blog_id;
-				} else {
-					$active_sites[ $plugin_or_theme ] = [ $site->blog_id ];
-				}
+				$active_counts[ $plugin_or_theme ] = ( $active_counts[ $plugin_or_theme ] ?? 0 ) + 1;
+				$active_sites[ $plugin_or_theme ][] = $site->blog_id;
 			}
 
 			$this->after_count();

--- a/inc/class-base-command.php
+++ b/inc/class-base-command.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Base Command class for WP-CLI functionality in a WordPress multisite network.
+ *
+ * This abstract class provides a foundation for creating WP-CLI commands
+ * that operate on multisite installations. It includes methods to fetch site data,
+ * process plugins or themes, and generate tabular output with various filters.
+ *
+ * @package NetworkPluginAuditor\WPCLI
+ */
+
+namespace NetworkPluginAuditor\WPCLI;
+
+use WP_CLI;
+use WP_Site;
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	/**
+	 * A base command for WP-CLI.
+	 */
+	abstract class Base_Command {
+		protected array $sites;
+
+		/**
+		 * Executes the command to retrieve and store all sites in a multisite installation.
+		 *
+		 * @param array $args Positional arguments passed to the command.
+		 * @param array $assoc_args Associative arguments passed to the command.
+		 *
+		 * @return void
+		 */
+		public function run( array $args, array $assoc_args ) : void {
+			if ( ! is_multisite() ) {
+				WP_CLI::error( 'This command can only be run on a multisite installation.' );
+
+				return;
+			}
+
+			$sites = get_sites( [ 'number' => 0 ] ); // Get all sites
+			if ( empty( $sites ) ) {
+				WP_CLI::error( 'No sites found in the network.' );
+
+				return;
+			}
+
+			$this->sites = $sites;
+		}
+
+		/**
+		 * Generates a filtered and sorted table based on active plugins or themes across a multisite installation.
+		 *
+		 * @param array  $list A list of plugins or themes to evaluate for active status.
+		 * @param array  $assoc_args An associative array of filters and sorting criteria, including:
+		 *                          - 'order-by': Sort the table by 'name' or 'active-sites'.
+		 *                          - 'min-active-sites': Minimum number of active sites required for inclusion.
+		 *                          - 'max-active-sites': Maximum number of active sites allowed for inclusion.
+		 *                          - 'site-id': Filter by a specific site ID.
+		 * @param string $column_name The name of the primary column to display in the table.
+		 *
+		 * @return array A filtered and sorted array of data, where each entry contains:
+		 *               - The primary column key with the plugin/theme name.
+		 *               - 'Active Sites': The count of sites where the plugin/theme is active.
+		 *               - 'Site IDs': A comma-separated list of site IDs where the plugin/theme is active.
+		 */
+		public function get_table( array $list, array $assoc_args, string $column_name ) : array {
+			$active_counts = array_fill_keys( $list, 0 );
+			$active_sites = array_fill_keys( $list, [] );
+
+			// Count active themes per site and store site IDs
+			foreach ( $this->sites as $site ) {
+				$plugins_or_themes = $this->before_count( $site );
+
+				foreach ( $plugins_or_themes as $plugin_or_theme ) {
+					if ( isset( $active_counts[ $plugin_or_theme ] ) ) {
+						$active_counts[ $plugin_or_theme ] ++;
+					} else {
+						$active_counts[ $plugin_or_theme ] = 1;
+					}
+
+					if ( isset( $active_sites[ $plugin_or_theme ] ) ) {
+						$active_sites[ $plugin_or_theme ][] = $site->blog_id;
+					} else {
+						$active_sites[ $plugin_or_theme ] = [ $site->blog_id ];
+					}
+				}
+
+				$this->after_count();
+			}
+
+			// Apply filters
+			$order_by = $assoc_args['order-by'] ?? 'name';
+			$min_sites_active = isset( $assoc_args['min-active-sites'] ) ? (int) $assoc_args['min-active-sites'] : null;
+			$max_sites_active = isset( $assoc_args['max-active-sites'] ) ? (int) $assoc_args['max-active-sites'] : null;
+			$filter_site_id = isset( $assoc_args['site-id'] ) ? (int) $assoc_args['site-id'] : null;
+
+			$table = [];
+			foreach ( $active_counts as $plugin_or_theme => $count ) {
+				// Apply min/max filters
+				if (
+					( $min_sites_active !== null && $count < $min_sites_active ) ||
+					( $max_sites_active !== null && $count > $max_sites_active )
+				) {
+					continue;
+				}
+
+				// Apply site ID filter, if provided
+				if (
+					$filter_site_id !== null &&
+					( empty( $active_sites[ $plugin_or_theme ] ) || ! in_array( $filter_site_id, $active_sites[ $plugin_or_theme ], false ) )
+				) {
+					continue;
+				}
+
+				$table[] = [
+					$column_name => $plugin_or_theme,
+					'Active Sites' => $count,
+					'Site IDs' => empty( $active_sites[ $plugin_or_theme ] ) ? 'None' : implode( ', ', $active_sites[ $plugin_or_theme ] ),
+				];
+			}
+
+			// Sort the table
+			if ( $order_by === 'active-sites' ) {
+				usort( $table, static function ( $a, $b ) {
+					return $b['Active Sites'] <=> $a['Active Sites'];
+				} );
+			} else {
+				usort( $table, static function ( $a, $b ) use ( $column_name ) {
+					return strcasecmp( $a[ $column_name ], $b[ $column_name ] );
+				} );
+			}
+
+			return $table;
+		}
+
+		/**
+		 * Executes operations to be performed before a count is initiated.
+		 *
+		 * @param WP_Site $site The site object for which the count will be prepared.
+		 *
+		 * @return array An array of data to support the count operation.
+		 */
+		abstract protected function before_count( WP_Site $site ) : array;
+
+		/**
+		 * Executes optional operations to be performed after a count is completed.
+		 *
+		 * @return void
+		 */
+		protected function after_count() : void {
+			// Optional
+		}
+	}
+}

--- a/inc/class-plugins-command.php
+++ b/inc/class-plugins-command.php
@@ -5,10 +5,10 @@
  * This class adds a custom command to WP-CLI to list all plugins in a multisite network
  * and display how many sites they are active on, with sorting and filtering options.
  *
- * @package NetworkPluginAuditor\WPCLI
+ * @package NetworkPluginAuditor\Commands
  */
 
-namespace NetworkPluginAuditor\WPCLI;
+namespace NetworkPluginAuditor\Commands;
 
 use WP_CLI;
 

--- a/inc/class-plugins-command.php
+++ b/inc/class-plugins-command.php
@@ -77,19 +77,8 @@ class Plugins_Command extends Base_Command {
 	 * @return array List of active plugins for the specified site.
 	 */
 	protected function before_count( mixed $site ) : array {
-		switch_to_blog( $site->blog_id );
-
-		$active_plugins = get_option( 'active_plugins', [] );
+		$active_plugins = get_blog_option( $site->blog_id, 'active_plugins', [] );
 
 		return $active_plugins;
-	}
-
-	/**
-	 * Finalizes operations after performing a count action.
-	 *
-	 * @return void
-	 */
-	protected function after_count() : void {
-		restore_current_blog();
 	}
 }

--- a/inc/class-plugins-command.php
+++ b/inc/class-plugins-command.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Plugins_Command class for WP-CLI.
+ *
+ * This class adds a custom command to WP-CLI to list all plugins in a multisite network
+ * and display how many sites they are active on, with sorting and filtering options.
+ *
+ * @package NetworkPluginAuditor\WPCLI
+ */
+
+namespace NetworkPluginAuditor\WPCLI;
+
+use WP_CLI;
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	/**
+	 * A test command for WP-CLI.
+	 */
+	class Plugins_Command {
+		/**
+		 * List all plugins in the network and how many sites they are active on, with sorting and filtering options.
+		 *
+		 * ## OPTIONS
+		 *
+		 * [--order-by=<field>]
+		 * : Order the results by 'name' (default) or 'active-sites'.
+		 * ---
+		 * default: name
+		 * options:
+		 *   - name
+		 *   - active-sites
+		 * ---
+		 *
+		 * [--min-active-sites=<number>]
+		 * : Only display plugins active on at least this number of sites.
+		 *
+		 * [--max-active-sites=<number>]
+		 * : Only display plugins active on no more than this number of sites.
+		 *
+		 * [--site-id=<number>]
+		 * : Only display plugins active on a particular site.
+		 * ## EXAMPLES
+		 *
+		 *     wp network-plugin-auditor plugins
+		 *     wp network-plugin-auditor plugins --order-by=active-sites
+		 *     wp network-plugin-auditor plugins --min-active-sites=2
+		 *     wp network-plugin-auditor plugins --max-active-sites=5 --site-id=1
+		 *     wp network-plugin-auditor plugins --min-active-sites=2 --max-active-sites=10 --order-by=active-sites
+		 *
+		 * @param array $args Positional arguments.
+		 * @param array $assoc_args Associative arguments.
+		 */
+		public function run( array $args, array $assoc_args ) : void {
+			if ( ! is_multisite() ) {
+				WP_CLI::error( 'This command can only be run on a multisite installation.' );
+
+				return;
+			}
+
+			$sites = get_sites( [ 'number' => 0 ] ); // Get all sites
+			if ( empty( $sites ) ) {
+				WP_CLI::error( 'No sites found in the network.' );
+
+				return;
+			}
+
+			$all_plugins = array_keys( get_plugins() );
+			$plugin_counts = array_fill_keys( $all_plugins, 0 );
+			$plugin_sites = array_fill_keys( $all_plugins, [] );
+
+			// Count active plugins per site and store site IDs
+			foreach ( $sites as $site ) {
+				switch_to_blog( $site->blog_id );
+
+				$active_plugins = get_option( 'active_plugins', [] );
+
+				foreach ( $active_plugins as $plugin ) {
+					if ( isset( $plugin_counts[ $plugin ] ) ) {
+						$plugin_counts[ $plugin ] ++;
+					} else {
+						$plugin_counts[ $plugin ] = 1;
+					}
+
+					if ( isset( $plugin_sites[ $plugin ] ) ) {
+						$plugin_sites[ $plugin ][] = $site->blog_id;
+					} else {
+						$plugin_sites[ $plugin ] = [ $site->blog_id ];
+					}
+				}
+
+				restore_current_blog();
+			}
+
+			// Apply filters
+			$order_by = $assoc_args['order-by'] ?? 'name';
+			$min_sites_active = isset( $assoc_args['min-active-sites'] ) ? (int) $assoc_args['min-active-sites'] : null;
+			$max_sites_active = isset( $assoc_args['max-active-sites'] ) ? (int) $assoc_args['max-active-sites'] : null;
+			$filter_site_id = isset( $assoc_args['site-id'] ) ? (int) $assoc_args['site-id'] : null;
+
+			$table = [];
+			foreach ( $plugin_counts as $plugin => $count ) {
+				// Apply min/max filters
+				if (
+					( $min_sites_active !== null && $count < $min_sites_active ) ||
+					( $max_sites_active !== null && $count > $max_sites_active )
+				) {
+					continue;
+				}
+
+				// Apply site ID filter, if provided
+				if (
+					$filter_site_id !== null &&
+					( empty( $plugin_sites[ $plugin ] ) || ! in_array( $filter_site_id, $plugin_sites[ $plugin ], false ) )
+				) {
+					continue;
+				}
+
+				$table[] = [
+					'Plugin' => $plugin,
+					'Active Sites' => $count,
+					'Site IDs' => empty( $plugin_sites[ $plugin ] ) ? 'None' : implode( ', ', $plugin_sites[ $plugin ] ),
+				];
+			}
+
+			// Sort the table
+			if ( $order_by === 'active-sites' ) {
+				usort( $table, static function ( $a, $b ) {
+					return $b['Active Sites'] <=> $a['Active Sites'];
+				} );
+			} else {
+				usort( $table, static function ( $a, $b ) {
+					return strcasecmp( $a['Plugin'], $b['Plugin'] );
+				} );
+			}
+
+			if ( empty( $table ) ) {
+				WP_CLI::log( 'No plugins found matching the criteria.' );
+
+				return;
+			}
+
+			WP_CLI\Utils\format_items( 'table', $table, [ 'Plugin', 'Active Sites', 'Site IDs' ] );
+		}
+	}
+}

--- a/inc/class-plugins-command.php
+++ b/inc/class-plugins-command.php
@@ -12,87 +12,84 @@ namespace NetworkPluginAuditor\WPCLI;
 
 use WP_CLI;
 
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
+/**
+ * A plugins command class for WP-CLI.
+ */
+class Plugins_Command extends Base_Command {
 	/**
-	 * A plugins command class for WP-CLI.
+	 * List all plugins in the network and how many sites they are active on, with sorting and filtering options.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--order-by=<field>]
+	 * : Order the results by 'name' (default) or 'active-sites'.
+	 * ---
+	 * default: name
+	 * options:
+	 *   - name
+	 *   - active-sites
+	 * ---
+	 *
+	 * [--min-active-sites=<number>]
+	 * : Only display plugins active on at least this number of sites.
+	 *
+	 * [--max-active-sites=<number>]
+	 * : Only display plugins active on no more than this number of sites.
+	 *
+	 * [--site-id=<number>]
+	 * : Only display plugins active on a particular site.
+	 * ## EXAMPLES
+	 *
+	 *     wp network-plugin-auditor plugins
+	 *     wp network-plugin-auditor plugins --order-by=active-sites
+	 *     wp network-plugin-auditor plugins --min-active-sites=2
+	 *     wp network-plugin-auditor plugins --max-active-sites=5 --site-id=1
+	 *     wp network-plugin-auditor plugins --min-active-sites=2 --max-active-sites=10 --order-by=active-sites
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Associative arguments.
 	 */
-	class Plugins_Command extends Base_Command {
-		/**
-		 * List all plugins in the network and how many sites they are active on, with sorting and filtering options.
-		 *
-		 * ## OPTIONS
-		 *
-		 * [--order-by=<field>]
-		 * : Order the results by 'name' (default) or 'active-sites'.
-		 * ---
-		 * default: name
-		 * options:
-		 *   - name
-		 *   - active-sites
-		 * ---
-		 *
-		 * [--min-active-sites=<number>]
-		 * : Only display plugins active on at least this number of sites.
-		 *
-		 * [--max-active-sites=<number>]
-		 * : Only display plugins active on no more than this number of sites.
-		 *
-		 * [--site-id=<number>]
-		 * : Only display plugins active on a particular site.
-		 * ## EXAMPLES
-		 *
-		 *     wp network-plugin-auditor plugins
-		 *     wp network-plugin-auditor plugins --order-by=active-sites
-		 *     wp network-plugin-auditor plugins --min-active-sites=2
-		 *     wp network-plugin-auditor plugins --max-active-sites=5 --site-id=1
-		 *     wp network-plugin-auditor plugins --min-active-sites=2 --max-active-sites=10 --order-by=active-sites
-		 *
-		 * @param array $args Positional arguments.
-		 * @param array $assoc_args Associative arguments.
-		 */
-		public function run( array $args, array $assoc_args ) : void {
-			parent::run( $args, $assoc_args );
+	public function run( array $args, array $assoc_args ) : void {
+		parent::run( $args, $assoc_args );
 
-			$all_plugins = array_keys( get_plugins() );
+		$all_plugins = array_keys( get_plugins() );
 
-			$column_name = 'Plugin';
-			$table = $this->get_table( $all_plugins, $assoc_args, $column_name );
+		$column_name = 'Plugin';
+		$table = $this->get_table( $all_plugins, $assoc_args, $column_name );
 
-			if ( empty( $table ) ) {
-				WP_CLI::log( 'No plugins found matching the criteria.' );
+		if ( empty( $table ) ) {
+			WP_CLI::log( 'No plugins found matching the criteria.' );
 
-				return;
-			}
-
-			WP_CLI\Utils\format_items( 'table', $table, [ $column_name, 'Active Sites', 'Site IDs' ] );
+			return;
 		}
 
-		/**
-		 * Retrieves the list of active plugins for a given site.
-		 *
-		 * This method switches to the specified site context, fetches its active plugins from the options table,
-		 * and then returns the list of active plugins.
-		 *
-		 * @param mixed $site The site object or data containing the blog ID of the site.
-		 *
-		 * @return array List of active plugins for the specified site.
-		 */
-		protected function before_count( mixed $site ) : array {
-			switch_to_blog( $site->blog_id );
+		WP_CLI\Utils\format_items( 'table', $table, [ $column_name, 'Active Sites', 'Site IDs' ] );
+	}
 
-			$active_plugins = get_option( 'active_plugins', [] );
+	/**
+	 * Retrieves the list of active plugins for a given site.
+	 *
+	 * This method switches to the specified site context, fetches its active plugins from the options table,
+	 * and then returns the list of active plugins.
+	 *
+	 * @param mixed $site The site object or data containing the blog ID of the site.
+	 *
+	 * @return array List of active plugins for the specified site.
+	 */
+	protected function before_count( mixed $site ) : array {
+		switch_to_blog( $site->blog_id );
 
-			return $active_plugins;
-		}
+		$active_plugins = get_option( 'active_plugins', [] );
 
-		/**
-		 * Finalizes operations after performing a count action.
-		 *
-		 * @return void
-		 */
-		protected function after_count() : void {
-			restore_current_blog();
-		}
+		return $active_plugins;
+	}
 
+	/**
+	 * Finalizes operations after performing a count action.
+	 *
+	 * @return void
+	 */
+	protected function after_count() : void {
+		restore_current_blog();
 	}
 }

--- a/inc/class-themes-command.php
+++ b/inc/class-themes-command.php
@@ -13,73 +13,71 @@ namespace NetworkPluginAuditor\WPCLI;
 use NetworkPluginAuditor\NetworkPluginAuditor;
 use WP_CLI;
 
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
+/**
+ * A themes command class
+ */
+class Themes_Command extends Base_Command {
 	/**
-	 * A themes command class
+	 * List all themes in the network and how many sites they are active on, with sorting and filtering options.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--order-by=<field>]
+	 * : Order the results by 'name' (default) or 'active-sites'.
+	 * ---
+	 * default: name
+	 * options:
+	 *   - name
+	 *   - active-sites
+	 * ---
+	 *
+	 * [--min-active-sites=<number>]
+	 * : Only display themes active on at least this number of sites.
+	 *
+	 * [--max-active-sites=<number>]
+	 * : Only display themes active on no more than this number of sites.
+	 *
+	 * [--site-id=<number>]
+	 * : Only display themes active on a particular site.
+	 * ## EXAMPLES
+	 *
+	 *     wp network-plugin-auditor themes
+	 *     wp network-plugin-auditor themes --order-by=active-sites
+	 *     wp network-plugin-auditor themes --min-active-sites=2
+	 *     wp network-plugin-auditor themes --max-active-sites=5 --site-id=1
+	 *     wp network-plugin-auditor themes --min-active-sites=2 --max-active-sites=10 --order-by=active-sites
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Associative arguments.
 	 */
-	class Themes_Command extends Base_Command {
-		/**
-		 * List all themes in the network and how many sites they are active on, with sorting and filtering options.
-		 *
-		 * ## OPTIONS
-		 *
-		 * [--order-by=<field>]
-		 * : Order the results by 'name' (default) or 'active-sites'.
-		 * ---
-		 * default: name
-		 * options:
-		 *   - name
-		 *   - active-sites
-		 * ---
-		 *
-		 * [--min-active-sites=<number>]
-		 * : Only display themes active on at least this number of sites.
-		 *
-		 * [--max-active-sites=<number>]
-		 * : Only display themes active on no more than this number of sites.
-		 *
-		 * [--site-id=<number>]
-		 * : Only display themes active on a particular site.
-		 * ## EXAMPLES
-		 *
-		 *     wp network-plugin-auditor themes
-		 *     wp network-plugin-auditor themes --order-by=active-sites
-		 *     wp network-plugin-auditor themes --min-active-sites=2
-		 *     wp network-plugin-auditor themes --max-active-sites=5 --site-id=1
-		 *     wp network-plugin-auditor themes --min-active-sites=2 --max-active-sites=10 --order-by=active-sites
-		 *
-		 * @param array $args Positional arguments.
-		 * @param array $assoc_args Associative arguments.
-		 */
-		public function run( array $args, array $assoc_args ) : void {
-			parent::run( $args, $assoc_args );
+	public function run( array $args, array $assoc_args ) : void {
+		parent::run( $args, $assoc_args );
 
-			$all_themes = array_keys( wp_get_themes( [ 'errors' => null ] ) );
+		$all_themes = array_keys( wp_get_themes( [ 'errors' => null ] ) );
 
-			$column_name = 'Theme';
-			$table = $this->get_table( $all_themes, $assoc_args, $column_name );
+		$column_name = 'Theme';
+		$table = $this->get_table( $all_themes, $assoc_args, $column_name );
 
-			if ( empty( $table ) ) {
-				WP_CLI::log( 'No themes found matching the criteria.' );
+		if ( empty( $table ) ) {
+			WP_CLI::log( 'No themes found matching the criteria.' );
 
-				return;
-			}
-
-			WP_CLI\Utils\format_items( 'table', $table, [ $column_name, 'Active Sites', 'Site IDs' ] );
+			return;
 		}
 
-		/**
-		 * Retrieves data related to the active theme of the provided site.
-		 *
-		 * @param mixed $site The site object or identifier containing the necessary blog ID information.
-		 *
-		 * @return array An array with the active theme details of the provided site.
-		 */
-		protected function before_count( mixed $site ) : array {
-			$auditor = NetworkPluginAuditor::get_instance();
-			$theme = $auditor->get_active_theme( $site->blog_id );
+		WP_CLI\Utils\format_items( 'table', $table, [ $column_name, 'Active Sites', 'Site IDs' ] );
+	}
 
-			return [ $theme ];
-		}
+	/**
+	 * Retrieves data related to the active theme of the provided site.
+	 *
+	 * @param mixed $site The site object or identifier containing the necessary blog ID information.
+	 *
+	 * @return array An array with the active theme details of the provided site.
+	 */
+	protected function before_count( mixed $site ) : array {
+		$auditor = NetworkPluginAuditor::get_instance();
+		$theme = $auditor->get_active_theme( $site->blog_id );
+
+		return [ $theme ];
 	}
 }

--- a/inc/class-themes-command.php
+++ b/inc/class-themes-command.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Themes_Command class for WP-CLI.
+ *
+ * This class adds a custom command to WP-CLI to list all themes in a multisite network
+ * and display how many sites they are active on, with sorting and filtering options.
+ *
+ * @package NetworkPluginAuditor\WPCLI
+ */
+
+namespace NetworkPluginAuditor\WPCLI;
+
+use NetworkPluginAuditor\NetworkPluginAuditor;
+use WP_CLI;
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	/**
+	 * A themes command class
+	 */
+	class Themes_Command extends Base_Command {
+		/**
+		 * List all themes in the network and how many sites they are active on, with sorting and filtering options.
+		 *
+		 * ## OPTIONS
+		 *
+		 * [--order-by=<field>]
+		 * : Order the results by 'name' (default) or 'active-sites'.
+		 * ---
+		 * default: name
+		 * options:
+		 *   - name
+		 *   - active-sites
+		 * ---
+		 *
+		 * [--min-active-sites=<number>]
+		 * : Only display themes active on at least this number of sites.
+		 *
+		 * [--max-active-sites=<number>]
+		 * : Only display themes active on no more than this number of sites.
+		 *
+		 * [--site-id=<number>]
+		 * : Only display themes active on a particular site.
+		 * ## EXAMPLES
+		 *
+		 *     wp network-plugin-auditor themes
+		 *     wp network-plugin-auditor themes --order-by=active-sites
+		 *     wp network-plugin-auditor themes --min-active-sites=2
+		 *     wp network-plugin-auditor themes --max-active-sites=5 --site-id=1
+		 *     wp network-plugin-auditor themes --min-active-sites=2 --max-active-sites=10 --order-by=active-sites
+		 *
+		 * @param array $args Positional arguments.
+		 * @param array $assoc_args Associative arguments.
+		 */
+		public function run( array $args, array $assoc_args ) : void {
+			parent::run( $args, $assoc_args );
+
+			$all_themes = array_keys( wp_get_themes( [ 'errors' => null ] ) );
+
+			$column_name = 'Theme';
+			$table = $this->get_table( $all_themes, $assoc_args, $column_name );
+
+			if ( empty( $table ) ) {
+				WP_CLI::log( 'No themes found matching the criteria.' );
+
+				return;
+			}
+
+			WP_CLI\Utils\format_items( 'table', $table, [ $column_name, 'Active Sites', 'Site IDs' ] );
+		}
+
+		/**
+		 * Retrieves data related to the active theme of the provided site.
+		 *
+		 * @param mixed $site The site object or identifier containing the necessary blog ID information.
+		 *
+		 * @return array An array with the active theme details of the provided site.
+		 */
+		protected function before_count( mixed $site ) : array {
+			$auditor = NetworkPluginAuditor::get_instance();
+			$theme = $auditor->get_active_theme( $site->blog_id );
+
+			return [ $theme ];
+		}
+	}
+}

--- a/inc/class-themes-command.php
+++ b/inc/class-themes-command.php
@@ -5,10 +5,10 @@
  * This class adds a custom command to WP-CLI to list all themes in a multisite network
  * and display how many sites they are active on, with sorting and filtering options.
  *
- * @package NetworkPluginAuditor\WPCLI
+ * @package NetworkPluginAuditor\Commands
  */
 
-namespace NetworkPluginAuditor\WPCLI;
+namespace NetworkPluginAuditor\Commands;
 
 use NetworkPluginAuditor\NetworkPluginAuditor;
 use WP_CLI;

--- a/network-plugin-auditor.php
+++ b/network-plugin-auditor.php
@@ -23,9 +23,15 @@ add_action( 'plugins_loaded', function() {
 	$plugin->init();
 
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		require_once __DIR__ . '/inc/class-audit-plugins-command.php';
+		require_once __DIR__ . '/inc/class-base-command.php';
+		require_once __DIR__ . '/inc/class-plugins-command.php';
+		require_once __DIR__ . '/inc/class-themes-command.php';
 		WP_CLI::add_command( 'network-plugin-auditor plugins', [
 			__NAMESPACE__ . '\\WPCLI\\Plugins_Command',
+			'run',
+		] );
+		WP_CLI::add_command( 'network-plugin-auditor themes', [
+			__NAMESPACE__ . '\\WPCLI\\Themes_Command',
 			'run',
 		] );
 	}

--- a/network-plugin-auditor.php
+++ b/network-plugin-auditor.php
@@ -27,11 +27,11 @@ add_action( 'plugins_loaded', function() {
 		require_once __DIR__ . '/inc/class-plugins-command.php';
 		require_once __DIR__ . '/inc/class-themes-command.php';
 		WP_CLI::add_command( 'network-plugin-auditor plugins', [
-			__NAMESPACE__ . '\\WPCLI\\Plugins_Command',
+			__NAMESPACE__ . '\\Commands\\Plugins_Command',
 			'run',
 		] );
 		WP_CLI::add_command( 'network-plugin-auditor themes', [
-			__NAMESPACE__ . '\\WPCLI\\Themes_Command',
+			__NAMESPACE__ . '\\Commands\\Themes_Command',
 			'run',
 		] );
 	}

--- a/network-plugin-auditor.php
+++ b/network-plugin-auditor.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
 Plugin Name: Network Plugin Auditor
 Plugin URI: http://wordpress.org/support/plugin/network-plugin-auditor
@@ -14,12 +13,20 @@ Domain Path: /languages
 
 namespace NetworkPluginAuditor;
 
-require_once __DIR__ . '/inc/class-network-plugin-auditor.php';
-
+use WP_CLI;
 /**
  * Kick it off.
  */
 add_action( 'plugins_loaded', function() {
+	require_once __DIR__ . '/inc/class-network-plugin-auditor.php';
 	$plugin = NetworkPluginAuditor::get_instance();
 	$plugin->init();
+
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		require_once __DIR__ . '/inc/class-audit-plugins-command.php';
+		WP_CLI::add_command( 'network-plugin-auditor plugins', [
+			__NAMESPACE__ . '\\WPCLI\\Plugins_Command',
+			'run',
+		] );
+	}
 } );


### PR DESCRIPTION
- [x] Creates a new `wp network-plugin-auditor` command as an CLI interface.
- [x] Creates subcommands `plugins` and `themes` for plugins and themes
- [x] These return a table of plugins/themes, Active Sites count, and list of Site IDs to inspect.
- [x] User can order by `active-sites` or plugin/theme `name` (default)
- [x] User can filter by minimum and maximum site count and `site-id`

Inactive plugins/themes are also listed.

![image](https://github.com/user-attachments/assets/72d21f1d-09ee-403b-8f3b-1e01d6fb52b1)


I used **Active Sites** instead of **Active Blogs** here as this is the modern nomenclature, and would suggest to update the plugin's admin UI to use the same, but didn't want to introduce side effects and/or break upstreaming.